### PR TITLE
レシピ・ユーザー・タイムライン一覧のデザイン変更を行いました。

### DIFF
--- a/:
+++ b/:
@@ -1,0 +1,30 @@
+レシピ投稿及び編集ページの作成完了
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch feature/add_recipe_post_and_edit_page
+# Changes to be committed:
+#	new file:   app/assets/images/add_a_photo.svg
+#	new file:   app/assets/images/add_photo_alternate.svg
+#	new file:   app/assets/images/add_to_photo.svg
+#	new file:   app/assets/images/delete.svg
+#	new file:   app/assets/images/remove_circle2.svg
+#	modified:   app/assets/stylesheets/breakpoints/_600up.scss
+#	modified:   app/assets/stylesheets/breakpoints/_960up.scss
+#	modified:   app/assets/stylesheets/breakpoints/base.scss
+#	modified:   app/assets/stylesheets/modules/button.scss
+#	modified:   app/assets/stylesheets/modules/comments.scss
+#	modified:   app/assets/stylesheets/modules/valiables.scss
+#	modified:   app/controllers/recipes_controller.rb
+#	modified:   app/helpers/application_helper.rb
+#	modified:   app/javascript/packs/application.js
+#	modified:   app/javascript/scripts/main.js
+#	modified:   app/views/comments/_comment.html.erb
+#	modified:   app/views/comments/_form.html.erb
+#	modified:   app/views/recipes/_form.html.erb
+#	modified:   app/views/recipes/_ingredient_fields.html.erb
+#	modified:   app/views/recipes/_step_fields.html.erb
+#	modified:   app/views/recipes/edit.html.erb
+#	modified:   app/views/recipes/new.html.erb
+#	modified:   app/views/recipes/show.html.erb
+#

--- a/app/assets/images/navigate_next.svg
+++ b/app/assets/images/navigate_next.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>

--- a/app/assets/images/read_more.svg
+++ b/app/assets/images/read_more.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24"><g><rect fill="none" height="24" width="24"/></g><g><g><rect height="2" width="9" x="13" y="7"/><rect height="2" width="9" x="13" y="15"/><rect height="2" width="6" x="16" y="11"/><polygon points="13,12 8,7 8,11 2,11 2,13 8,13 8,17"/></g></g></svg>

--- a/app/assets/stylesheets/breakpoints/_600up.scss
+++ b/app/assets/stylesheets/breakpoints/_600up.scss
@@ -34,6 +34,12 @@
   &__container {
     // 1行の要素を左右に寄せる。flexの親要素に指定。
     justify-content: space-between;
+
+    &::after {
+      display: block;
+      content: "";
+      width: 32%;
+    }
   }
   &__item {
     flex-basis: 32%;
@@ -56,6 +62,24 @@
   }
 }
 // トップページここまで
+// レシピ一覧ここから
+.user-list {
+  &__container {
+    &::after {
+      display: block;
+      content: "";
+      width: 32%;
+    }
+  }
+  &__item {
+    flex-basis: 32%;
+  }
+
+  &__img {
+    height: 200px;
+  }
+}
+// レシピ一覧ここまで
 
 // レシピ詳細ここから
 .description {
@@ -115,15 +139,6 @@
 }
 
 // 投稿・一覧ボタンここまで
-
-// フォロー・フォロワー詳細ページここから
-.follow {
-  &__img {
-    height: 75px;
-    width: 75px;
-  }
-}
-// フォロー・フォロワー詳細ページここまで
 
 // ログインページここから
 .login {

--- a/app/assets/stylesheets/breakpoints/_960up.scss
+++ b/app/assets/stylesheets/breakpoints/_960up.scss
@@ -53,9 +53,6 @@
   &__container {
     justify-content: space-between;
   }
-  &__item {
-    flex-basis: 24%;
-  }
 
   &__img {
     height: 290px;

--- a/app/assets/stylesheets/breakpoints/base.scss
+++ b/app/assets/stylesheets/breakpoints/base.scss
@@ -89,6 +89,9 @@ img {
 .subheader {
   @extend .content-width;
   @extend .mb-sm;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .logo {
@@ -272,6 +275,10 @@ img {
     @extend .content-width;
     @extend .font-md;
     color: $UserNameColor;
+  }
+
+  & > .cooking-title {
+    @extend .content-width;
   }
 }
 
@@ -555,6 +562,63 @@ img {
 }
 
 // レシピ詳細ページここまで
+//ユーザー一覧ページここから
+.user-list {
+  &__container {
+    @extend .content-width;
+    @extend .mb-lg;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  &__item {
+    @extend .mb-sm;
+    flex-basis: 47%;
+    border: 1px solid $ItemBorderColor;
+    border-radius: 4px;
+    text-decoration: none !important;
+
+    &:hover {
+      background-color: $ItemHoverColor;
+      opacity: 0.75;
+    }
+  }
+
+  &__img {
+    @extend .mb-sm;
+    height: 130px;
+    overflow: hidden;
+
+    & > img {
+      object-fit: cover;
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+  &__detail {
+    padding-left: 10px;
+  }
+
+  &__name {
+    @extend .font-sm;
+    font-weight: 600;
+    display: inline-block;
+    color: $RecipeTitleColor;
+    text-decoration: none !important;
+  }
+
+  &__count {
+    @extend .font-sm;
+    color: $SubTitle;
+  }
+
+  & > .cooking-title {
+    @extend .content-width;
+  }
+}
+//ユーザー一覧ページここまで
 
 // ユーザー詳細ページここから
 .user {
@@ -599,14 +663,6 @@ img {
     display: flex;
     justify-content: space-between;
     border-bottom: 2px solid $ItemBorderColor;
-
-    & > div {
-      &:nth-child(3) {
-        &::after {
-          display: none;
-        }
-      }
-    }
   }
 
   &__tab {
@@ -623,6 +679,10 @@ img {
       top: 10px;
       width: 1px;
       height: 28px;
+    }
+
+    &:last-child::after {
+      display: none;
     }
 
     & > p {
@@ -660,48 +720,6 @@ img {
 
 // 投稿・一覧ボタンここまで
 
-// フォロー・フォロワー詳細ページここから
-.follow {
-  &__item {
-    @extend .content-width;
-    @extend .mb-sm;
-    @extend .pb-sm;
-    display: flex;
-    align-items: center;
-    border-bottom: 1px solid $ItemBorderColor;
-  }
-
-  &__img {
-    @extend .mr-sm;
-    height: 50px;
-    width: 50px;
-    overflow: hidden;
-    border-radius: 4px;
-
-    &:hover {
-      background-color: $ItemHoverColor;
-      opacity: 0.75;
-    }
-
-    & > img {
-      object-fit: cover;
-      height: 100%;
-      width: 100%;
-    }
-  }
-
-  &__name {
-    @extend .font-md;
-    text-decoration: none;
-    color: $UserNameColor;
-
-    &:hover {
-      color: $NameHoverColor;
-      text-decoration: underline;
-    }
-  }
-}
-// フォロー・フォロワー詳細ページここまで
 // ログインページここから
 .login {
   position: relative;

--- a/app/assets/stylesheets/modules/button.scss
+++ b/app/assets/stylesheets/modules/button.scss
@@ -97,6 +97,10 @@
   }
 }
 
+.btn-center {
+  text-align: center;
+}
+
 .add-field-btn {
   display: block;
   font-size: 16px;
@@ -116,7 +120,8 @@
 }
 
 .remove-field-btn,
-.add-photo-btn {
+.add-photo-btn,
+.read_more-btn {
   height: 40px;
   width: 40px;
   overflow: hidden;
@@ -126,8 +131,4 @@
     height: 100%;
     width: 100%;
   }
-}
-
-.submit-btn {
-  text-align: center;
 }

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,8 +1,12 @@
 class HomesController < ApplicationController
   def index
     if user_signed_in?
-      @list = Recipe.page(params[:page])
+      @list = Recipe.page(params[:page]).limit(3)
       @tweet = current_user.feed.limit(3)
     end
+  end
+
+  def tweet_index
+    @tweet = current_user.feed
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -3,6 +3,7 @@ class RecipesController < ApplicationController
 
   def index
     @recipes = Recipe.all
+    @list = Recipe.page(params[:page])
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show , :destroy, :following, :followers]
   def index
-    @users = User.page(params[:page]).per(10)
+    @users = User.page(params[:page]).per(6)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,10 +99,6 @@ class User < ApplicationRecord
   def validate_name
     errors.add(:name, :invalid) if User.where(email: name).exists?
   end
-
-  def display_avatar
-    avatar.variant(combine_options: {resize_to_fill: [200, 200], border:5})
-  end
   
   def follow(other_user)
     self.following << other_user

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -24,18 +24,24 @@
   </section>
 
   <section class="list">
-      <div class="subheader">
-        <div class="main-title">New Arrival</div>
-        <div class="sub-title">新しいレシピを見つけよう</div>
+    <div class="subheader">
+      <div>
+        <p class="main-title">New Arrival</p>
+        <p class="sub-title">新しいレシピを見つけよう</p>
       </div>
-      <%= render 'shared/recipe_list' %>
+      <%= link_to image_tag('read_more', class: "read_more-btn"), recipes_path %>
+    </div>
+    <%= render 'shared/recipe_list' %>
   </section>
   
   <section class="tweet">
-      <div class="subheader">
-        <div class="main-title">Follow Recipe</div>
-        <div class="sub-title">フォロー中のレシピ</div>
+    <div class="subheader">
+      <div>
+        <p class="main-title">Follow Recipe</p>
+        <p class="sub-title">フォロー中のレシピ</p>
       </div>
-      <%= render 'shared/recipe_tweet' %>
+      <%= link_to image_tag('read_more', class: "read_more-btn"), recipes_tweet_path %>
+    </div>
+    <%= render 'shared/recipe_tweet' %>
   </section>
 </main>

--- a/app/views/homes/tweet_index.html.erb
+++ b/app/views/homes/tweet_index.html.erb
@@ -1,0 +1,6 @@
+<%= render 'layouts/notifications' %>
+
+<section class="list">
+  <div class="cooking-title">タイムライン</div>
+  <%= render 'shared/recipe_tweet' %>
+</section>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -41,7 +41,7 @@
     </div>
   </section>
 
-  <div class="submit-btn"><%= f.button "送信する" , class:"btn slide-bg"%></div>
+  <div class="btn-center"><%= f.button "送信する" , class:"btn slide-bg"%></div>
   
   <% end %>
 </main>

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -1,3 +1,3 @@
 <%= render 'form', recipe: @recipe %>
 
-<div class="submit-btn"><%= link_to '編集をやめる', @recipe, class:"btn edit-cancel"%></div>
+<div class="btn-center"><%= link_to '編集をやめる', @recipe, class:"btn edit-cancel"%></div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,24 +1,6 @@
-<% @title = "レシピ投稿一覧" %>
 <%= render 'layouts/notifications' %>
 
-<h2 class="page_title">レシピ一覧</h2>
-
-<div class="row">
-  <% @recipes.each do |recipe| %>
-    <div class="col-lg-4 col-sm-6 mb-3 recipe-box">
-      <%= image_tag recipe.display_image, class: 'img-thumbnail recipe-index' if recipe.image.attached? %>
-      <div class="recipe-link">
-        <ul>
-          <li><%= recipe.title %></li>
-          <li><%= recipe.description %></li>
-          <li>
-            <%= link_to 'Show', recipe %> |
-            <%= link_to 'Edit', edit_recipe_path(recipe) %> |
-            <%= link_to 'Destroy', recipe, method: :delete, data: { confirm: 'Are you sure?'} %>
-          </li>
-          
-        </ul>
-      </div>
-    </div>
-  <% end %>
-</div>
+<section class="list">
+  <div class="cooking-title">レシピ一覧</div>
+  <%= render 'shared/recipe_list' %>
+</section>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,3 +1,7 @@
+<%= link_to(user_path(@user), class:'user__tab') do %>
+  <p>レシピ数</p>
+  <p class="user__count"><%= @user.recipes.count %></p>
+<% end %>
 <%= link_to(following_user_path(@user), class:'user__tab') do %>
   <p>フォロー</p>
   <p class="user__count" id="following"><%= @user.following.count %></p>
@@ -5,8 +9,4 @@
 <%= link_to(followers_user_path(@user), class:'user__tab') do %>
   <p>フォロワー</p>
   <p class="user__count" id="followers"><%= @user.followers.count %></p>
-<% end %>
-<%= link_to(user_path(@user), class:'user__tab') do %>
-  <p>レシピ数</p>
-  <p class="user__count"><%= @user.recipes.count %></p>
 <% end %>

--- a/app/views/shared/_user-list.html.erb
+++ b/app/views/shared/_user-list.html.erb
@@ -1,0 +1,18 @@
+<div class="user-list__container">
+  <% @users.each do |user| %>
+    <%= link_to(user_path(id: user.id), class: "user-list__item") do %>
+    <div class="user-list__img">
+      <% if user.avatar.attached? %>
+        <%= image_tag(user.avatar) %>
+      <% else %>
+        <%= image_tag('default_user.png') %>
+      <% end %>
+    </div>
+    <div class="user-list__detail">
+      <p class="user-list__name"><%= user.name %></p>
+      <p class="user-list__count">レシピ投稿数: <%= user.recipes.size %></p>
+    </div>
+    <% end %>
+  <% end %>
+</div>
+

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,8 +1,0 @@
-<div class="users_list">
-<% if user.avatar.attached? %>
-  <%= link_to image_tag(user.display_avatar), user_path(id: user.id) %>
-<% else %>
-  <%= link_to image_tag('default_user.png', :size => "200x200" ), user_path(id: user.id) %>
-<% end %>
-  <p><%= user.name %></p>
-</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,9 +1,7 @@
 <% @title = "ユーザー一覧" %>
 
-<h2 class="page_title">All Users</h2>
-
-<%= render 'path' %>
-
-<%= render @users %>
-
-<%= paginate @users %>
+<section class="user-list">
+  <p class="cooking-title">ユーザー一覧</p>
+  <%= render 'shared/user-list' %>
+  <%= paginate @users %>
+</section>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -2,18 +2,9 @@
   <%= render 'show_user' %>
 </section>
 
-<section class="follow">
+<section class="user-list">
   <div class="subheader">
     <div class="main-title"><%= @title %></div>
   </div>
-  <div class="follow__container">
-    <% @users.each do |user| %>
-      <div class="follow__item">
-        <%= link_to(user_path(id: user.id), class:'follow__img') do %>
-          <%= image_tag(user.avatar) if user.avatar.attached? %>
-        <% end %>
-        <%= link_to user.name, user_path(id: user.id), class:'follow__name' %>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/user-list' %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'homes#index'
+  get 'recipes/tweet', to: 'homes#tweet_index'
   
   # devise_for :users
   devise_for :users, controllers: {


### PR DESCRIPTION
【レシピ一覧ページの変更点】
listセクション配下にあるcooking-titleクラスのみcontent-widthを付与しました。
レシピ一覧ページにrecipe_listパーシャルを適用しました。
justify-content: space-betweenの最後の行を左寄せにしました。

【ユーザー一覧ページの変更点】
viewsのsharedフォルダにuser-listパーシャルを作成しました。
ユーザー一覧ページとユーザー詳細ページのフォロー・フォロワー一覧にuser-listパーシャルを適用しました。

パーシャルで統一したため、followクラスについては削除いたしました。
justify-content: space-betweenの最後の行を左寄せにしました。

【タイムライン一覧ページの変更点】
homeControllerにtweet_indexアクションを追加し、トップページからタイムライン一覧ページにアクセスできるようにしました。

【その他修正点】
submit-btnクラスをbtn-centerクラスに名前変更しました。
ユーザー詳細ページの「レシピ数」の箇所を一番初めに配置しました。
レシピ数 | フォロー | フォロワー |となっていたので、レシピ数 | フォロー | フォロワー に変更しました。