### PR TITLE
トップページのみにモバイルメニューが表示される事象を改善しました

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,8 +1,3 @@
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
@@ -12,15 +7,3 @@ require("@rails/activestorage").start()
 
 require("scripts/vendors/scroll-polyfill")
 require("scripts/main")
-
-
-
-
-
-
-// Uncomment to copy all static images under ../images to the output folder and reference
-// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
-// or the `imagePath` JavaScript helper below.
-//
-// const images = require.context('../images', true)
-// const imagePath = (name) => images(name, true)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body>
     <div id="global-container">
+      <%= render 'shared/mobile-menu' %>
       <div id="container">
         <div class="mobile-menu__cover"></div>
         <div class="nav-trigger"></div>
@@ -20,7 +21,6 @@
           <%= yield %>
         </div>
       </div>
-      <%= render 'shared/mobile-menu' %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
 application.html.erbの<%= render 'shared/mobile-menu' %>の位置をcontainerクラスの上にしたところ改善しました。