### PR TITLE
Feature/add pagenation

### DIFF
--- a/app/assets/stylesheets/breakpoints/_600up.scss
+++ b/app/assets/stylesheets/breakpoints/_600up.scss
@@ -239,3 +239,18 @@
   }
 }
 // 保存中の食材についてここまで
+
+// ページネーションここから
+.pagination {
+  &>.page,
+  .first,
+  .prev,
+  .next,
+  .last {
+    margin: 0 10px;
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+  }
+}
+// ページネーションここまで

--- a/app/assets/stylesheets/templates/inventories.scss
+++ b/app/assets/stylesheets/templates/inventories.scss
@@ -1,6 +1,5 @@
 .inventory {
   @extend .content-width;
-  @extend .mb-sm;
 
   &__container {
     @extend .flex;

--- a/app/assets/stylesheets/templates/pagination.scss
+++ b/app/assets/stylesheets/templates/pagination.scss
@@ -1,0 +1,32 @@
+.pagination {
+  @extend .content-width;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 30px;
+
+  &>.page,
+  .first,
+  .prev,
+  .next,
+  .last {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    @extend .font-md;
+    margin: 0 5px;
+    width: 35px;
+    height: 35px;
+    line-height: 35px;
+
+    & > a {
+      color: $--c-brown;
+    }
+  }
+
+  & > .active {
+    background-color: $--c-brown;
+    border-radius: 100%;
+    color: $--c-white;
+  }
+}

--- a/app/assets/stylesheets/templates/recipe-list.scss
+++ b/app/assets/stylesheets/templates/recipe-list.scss
@@ -1,4 +1,6 @@
 .list {
+  @extend .mb-lg;
+  
   & .tag {
     width: 100%
   }
@@ -6,7 +8,6 @@
   &__container {
     @extend .flex;
     @extend .content-width;
-    @extend .mb-lg;
   }
 
   &__item {

--- a/app/assets/stylesheets/templates/user.scss
+++ b/app/assets/stylesheets/templates/user.scss
@@ -4,7 +4,6 @@
 
   &__container {
     @extend .content-width;
-    @extend .mb-lg;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;

--- a/app/assets/stylesheets/templates/user.scss
+++ b/app/assets/stylesheets/templates/user.scss
@@ -1,5 +1,7 @@
 //ユーザー一覧ページここから
 .user-list {
+  @extend .mb-lg;
+
   &__container {
     @extend .content-width;
     @extend .mb-lg;
@@ -48,6 +50,10 @@
   &__count {
     @extend .font-sm;
     color: $--c-dark-gray;
+  }
+
+  & > .consultation {
+    margin-bottom: 0 !important;
   }
 }
 //ユーザー一覧ページここまで

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -3,7 +3,7 @@ class ConsultationsController < ApplicationController
   before_action :set_consultation, only: [:show, :edit, :update, :destroy]
 
   def index
-    @consultations = Consultation.page(params[:page])
+    @consultations = Consultation.page(params[:page]).per(6)
   end
 
   def show

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,7 +1,7 @@
 class HomesController < ApplicationController
   def index
     @recipes = Recipe.page(params[:page]).limit(3)
-    @consultations = Consultation.page(params[:page]).order(impressions_count: 'DESC')
+    @consultations = Consultation.page(params[:page]).per(3)
     @tweet = current_user.feed.limit(3)
   end
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -6,6 +6,6 @@ class HomesController < ApplicationController
   end
 
   def tweet_index
-    @tweet = current_user.feed
+    @tweet = current_user.feed.page(params[:page]).per(6)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -4,7 +4,7 @@ class RecipesController < ApplicationController
 
   def index
     @recipes = params[:tag_id].present? ? Tag.find(params[:tag_id]).recipes : Recipe.all
-    @recipes = @recipes.page(params[:page])
+    @recipes = @recipes.page(params[:page]).per(6)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,13 +29,13 @@ class UsersController < ApplicationController
 
   def consultations
     @title = "Consultation"
-    @consultations = @user.consultations.page(params[:page])
+    @consultations = @user.consultations.page(params[:page]).per(3)
     render 'show_consultation'
   end
 
   def inventories
     @title = "Inventory"
-    @inventories = @user.inventories.page(params[:page]).order(expiration_date: 'ASC')
+    @inventories = @user.inventories.page(params[:page]).order(expiration_date: 'ASC').per(6)
     render 'show_inventory'
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @recipes = @user.recipes.page(params[:page])
+    @recipes = @user.recipes.page(params[:page]).per(6)
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,14 +16,14 @@ class UsersController < ApplicationController
 
   def following
     @title = "Following"
-    @users = @user.following.page(params[:page])
+    @users = @user.following.page(params[:page]).per(6)
     render 'show_follow'
   end
 
 
   def followers
     @title = "Followers"
-    @users = @user.followers.page(params[:page])
+    @users = @user.followers.page(params[:page]).per(6)
     render 'show_follow'
   end
 

--- a/app/javascript/scripts/main.js
+++ b/app/javascript/scripts/main.js
@@ -6,15 +6,10 @@ window.addEventListener('turbolinks:load', function () {
 	new addFields();
 	new removeFields();
 	
-	new imgPreView();
-	// if (location.pathname.match("recipes/new")) {
-	// 	new imgPreView();
-	// }
-
-	// if (location.pathname.match("inventory/_form")) {
-	// 	new imgPreView();
-	// }
-
+	// new imgPreView();
+	if (document.URL.match(/new|edit/)) {
+		new imgPreView();
+	}
 
 });
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,7 @@ class User < ApplicationRecord
               foreign_key: "followed_id",
               dependent:   :destroy
 
+  # フォロー機能について
   has_many :following,
               through: :active_relationships,
               source: :followed

--- a/app/views/consultations/index.html.erb
+++ b/app/views/consultations/index.html.erb
@@ -1,2 +1,3 @@
 <div class="cooking-title">相談一覧</div>
 <%= render 'shared/recipe_consultation' %>
+<%= paginate @consultations %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -48,7 +48,7 @@
     <div class="subheader">
       <div>
         <p class="main-title">TimeLine</p>
-        <p class="sub-title">フォロー中のレシピ</p>
+        <p class="sub-title">フォローしている方のレシピをチェック</p>
       </div>
       <%= link_to image_tag('read_more', class: "read_more-btn"), recipes_tweet_path %>
     </div>

--- a/app/views/homes/tweet_index.html.erb
+++ b/app/views/homes/tweet_index.html.erb
@@ -3,4 +3,5 @@
 <section class="list">
   <div class="cooking-title">タイムライン</div>
   <%= render 'shared/recipe_tweet' %>
+  <%= paginate @tweet %>
 </section>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,11 @@
-<li class="page-item">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
-</li>
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,8 @@
-<li class='page-item disabled'>
-  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
-</li>
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,11 @@
-<li class="page-item">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
-</li>
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,11 @@
-<li class="page-item">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
-</li>
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,9 +1,12 @@
-<% if page.current? %>
-  <li class="page-item active">
-    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
-  </li>
-<% else %>
-  <li class="page-item">
-    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
-  </li>
-<% end %>
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' active' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,17 +1,23 @@
-<%= paginator.render do %>
-  <nav>
-    <ul class="pagination">
-      <%= first_page_tag unless current_page.first? %>
-      <%= prev_page_tag unless current_page.first? %>
-      <% each_page do |page| %>
-        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
-          <%= page_tag page %>
-        <% elsif !page.was_truncated? -%>
-          <%= gap_tag %>
-        <% end %>
-      <% end %>
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
       <%= next_page_tag unless current_page.last? %>
-      <%= last_page_tag unless current_page.last? %>
-    </ul>
+    <% end %>
   </nav>
-<% end %>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,11 @@
-<li class="page-item">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
-</li>
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -4,4 +4,5 @@
   <div class="cooking-title">レシピ一覧</div>
   <%= render 'shared/recipe_tag_list' %>
   <%= render 'shared/recipe_list' %>
+  <%= paginate @recipes %>
 </section>

--- a/app/views/shared/_recipe_tweet.html.erb
+++ b/app/views/shared/_recipe_tweet.html.erb
@@ -2,7 +2,11 @@
   <% @tweet.each do |recipe| %>
     <div class="tweet__item">
       <%= link_to(recipe_path(id: recipe.id), class:'tweet__img') do %>
-        <%= image_tag(recipe.image) if recipe.image.attached? %>
+        <%  if recipe.image.attached? %>
+          <%= image_tag(recipe.image) %>
+        <% else %>
+          <%= image_tag 'no_image' %>
+        <% end %>
       <% end %>
       <div class="tweet__detail">
         <span class="timestamp"><%= recipe.created_at.to_s(:datetime_jp) %></span><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,5 +14,7 @@
   <% end %>
 </section>
 
+<%= paginate @recipes %>
+
 
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,9 +12,9 @@
   <% else %>
     <p class="list__notthing"><%= "#{@user.name}さんの投稿はありません。" %></p>
   <% end %>
+  <%= paginate @recipes %>
 </section>
 
-<%= paginate @recipes %>
 
 
 

--- a/app/views/users/show_consultation.html.erb
+++ b/app/views/users/show_consultation.html.erb
@@ -13,6 +13,6 @@
   <% else %>
     <p class="list__notthing"><%= "#{@user.name}さんの相談はありません。" %></p>
   <% end %>
-  
+  <%= paginate @consultations %>
 </section>
 

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -7,4 +7,5 @@
     <div class="main-title"><%= @title %></div>
   </div>
   <%= render 'shared/user-list' %>
+  <%= paginate @users %>
 </section>

--- a/app/views/users/show_inventory.html.erb
+++ b/app/views/users/show_inventory.html.erb
@@ -9,6 +9,8 @@
   </div>
 
   <%= render 'shared/food_inventory' %>
+  
+  <%= paginate @inventories %>
 
   <div class="btn-center"><%= link_to '保存中の食材を登録', new_inventory_path, class:"btn slide-bg" %></div>
 

--- a/db/seeds/consultation.rb
+++ b/db/seeds/consultation.rb
@@ -1,0 +1,13 @@
+puts 'Start inserting seed "recipes" ...'
+
+20.times do |n|
+  consultation = Consultation.new{[
+    user_id: "1",
+    title: "相談#{n+1}",
+    content: "相談#{n+1}の内容"
+  ]}
+
+  consultation.save
+
+  puts "\"#{consultation.title}\" has created!"
+end

--- a/db/seeds/recipe.rb
+++ b/db/seeds/recipe.rb
@@ -1,0 +1,20 @@
+puts 'Start inserting seed "recipes" ...'
+
+20.times do |n|
+  recipe = Recipe.new({
+    user_id: "1",
+    title: "#{n+1}番目のレシピ",
+    description: "#{n+1}番目のレシピ説明",
+    ingredients_attributes: [{
+      content: "材料#{n+1}",
+      quantity: "分量#{n+1}"
+    }],
+    steps_attributes: [{
+      direction: "作り方#{n+1}"
+    }]
+  })
+
+  recipe.save
+
+  puts "\"#{recipe.title}\" has created!"
+end


### PR DESCRIPTION
bootstrapのページネーションを削除し、デフォルトのページネーションを導入し、スタイルを変更しました。
レシピのシードデータを作成しました。(user_idが1の方に紐づくシードデータ)
レシピ一覧にページネーションを追加。1ページあたり6つのアイテムを表示される仕様にしました。
ユーザー詳細ページのレシピ一覧にページネーションを追加。1ページあたり6つのアイテムを表示される仕様にしました。
タイムライン一覧にもページネーションを追加

ユーザー一覧ページにページネーションを追加。
相談一覧ページにページネーションを追加
1ページ当たり6件の投稿が表示される仕様に変更
トップページの相談は3件の投稿が表示されるように変更

ユーザー詳細ページ内の相談一覧ページは1ページごとに3つの要素が表示される仕様に変更

ユーザー詳細ページ内の保存中の食材一覧ページにページネーションを追加
1ページごとに表示される要素を6個としました。

ユーザー詳細ページ内のフォロー/フォロワー一覧ページにページネーションを追加。
1ページ当たり6人が表示される仕様にしました。

【スタイルの修正点】
user-list__containerクラスの@extend mg-lgを削除
listクラスの@extend .mb-lg;の位置を変更
user-listクラス配下のconsultationクラスだけmargin-bottomを0にしました。

【その他変更点】
画像プレビューイベントをパスにnewとeditが含まれているもののみ発火させる仕様にしました。