### PR TITLE
Feature/create list page of likes

### DIFF
--- a/app/assets/stylesheets/breakpoints/_600up.scss
+++ b/app/assets/stylesheets/breakpoints/_600up.scss
@@ -132,11 +132,11 @@
   }
 
   &__info {
-    flex-basis: 45%;
+    flex-basis: 42%;
   }
 
   &__submenu {
-    flex-basis: 45%;
+    flex-basis: 42%;
   }
 }
 

--- a/app/assets/stylesheets/breakpoints/base.scss
+++ b/app/assets/stylesheets/breakpoints/base.scss
@@ -155,3 +155,9 @@ img {
     display: none;
   }
 }
+
+.notthing {
+  @extend .content-width;
+  @extend .font-md;
+  color: $--c-brown;
+}

--- a/app/assets/stylesheets/templates/recipe-list.scss
+++ b/app/assets/stylesheets/templates/recipe-list.scss
@@ -76,10 +76,4 @@
     align-items: flex-end;
     color: $--c-brown !important;
   }
-
-  &__notthing {
-    @extend .content-width;
-    @extend .font-md;
-    color: $--c-brown;
-  }
 }

--- a/app/assets/stylesheets/templates/user.scss
+++ b/app/assets/stylesheets/templates/user.scss
@@ -64,9 +64,38 @@
 
   &__inner {
     @extend .flex;
+    @extend .mb-sm;
     align-items: center;
     padding-top: 10px;
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    align-self: center;
+  }
+
+  &__img {
+    @extend .mr-sm;
+    height: 75px;
+    width: 75px;
+    overflow: hidden;
+    border-radius: 100%;
+    align-self: center;
+
+    &>img {
+      object-fit: cover;
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+  &__name {
+    @extend .font-lr;
     @extend .mb-sm;
+    color: $--c-brown;
+    font-weight: bold;
+    align-self: center;
   }
 
   &__stats {
@@ -74,6 +103,22 @@
     display: flex;
     justify-content: space-between;
     border-bottom: 2px solid $--c-light-gray;
+  }
+
+  &__follow_stats {
+    @extend .mb-sm;
+    display: flex;
+    justify-content: center;
+  }
+  
+  &__follow {
+    display: flex;
+    @extend .font-sm;
+    color: $--c-brown !important;
+
+    &:last-child {
+      margin-left: 30px;
+    }
   }
 
   &__tab {
@@ -113,33 +158,6 @@
       opacity: 0.5;
       transition: opacity 0.3s;
     }
-  }
-
-  &__info {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  &__img {
-    @extend .mr-sm;
-    height: 75px;
-    width: 75px;
-    overflow: hidden;
-    border-radius: 100%;
-
-    & > img {
-      object-fit: cover;
-      height: 100%;
-      width: 100%;
-    }
-  }
-
-  &__name {
-    @extend .font-lr;
-    @extend .mb-sm;
-    color: $--c-brown;
-    font-weight: bold;
   }
 
   &__submenu {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,14 +15,16 @@ class UsersController < ApplicationController
   end
 
   def following
-    @title = "Following"
+    @title = "さんがフォロー中"
+    @message = "まだ誰もフォローしていません。"
     @users = @user.following.includes([:recipes], [avatar_attachment: :blob]).page(params[:page]).per(6)
     render 'show_follow'
   end
 
 
   def followers
-    @title = "Followers"
+    @title = "さんのフォロワー"
+    @message = "まだ誰からもフォローされていません。"
     @users = @user.followers.includes([:recipes], [avatar_attachment: :blob]).page(params[:page]).per(6)
     render 'show_follow'
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :following, :followers, :consultations]
-  before_action :set_user, only: [:show , :destroy, :following, :followers, :consultations, :inventories]
+  before_action :set_user, only: [:show , :destroy, :following, :followers, :consultations, :favorites, :inventories]
   def index
     @users = User.includes([:recipes], [avatar_attachment: :blob]).page(params[:page]).per(6).order(id: :ASC)
   end
@@ -33,6 +33,12 @@ class UsersController < ApplicationController
     @title = "Consultation"
     @consultations = @user.consultations.includes([:consultation_comments], [:interests]).page(params[:page]).per(3)
     render 'show_consultation'
+  end
+
+  def favorites
+    @title = "Favorite"
+    @recipes = @user.favorite_recipes.includes([user: { avatar_attachment: :blob }], [:favorites], [image_attachment: :blob]).page(params[:page]).per(6)
+    render 'show_favorite'
   end
 
   def inventories

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ApplicationRecord
   # いいね機能関連
   has_many :favorites, dependent: :destroy
 
+  has_many :favorite_recipes, through: :favorites, source: :recipe
+
   # 相談気になる機能関連
   has_many :interests, dependent: :destroy
   # アイコン画像追加のため

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -2,6 +2,10 @@
   <p>レシピ</p>
   <p class="user__count"><%= @user.recipes.length %></p>
 <% end %>
+<%= link_to(favorites_user_path(@user), class:'user__tab') do %>
+  <p>いいね</p>
+  <p class="user__count" id="following"><%= @user.favorites.length %></p>
+<% end %>
 <%= link_to(consultations_user_path(@user), class:'user__tab') do %>
   <p>相談</p>
   <p class="user__count"><%= @user.consultations.length %></p>
@@ -12,11 +16,5 @@
   <p class="user__count"><%= @user.inventories.length %></p>
   <% end %>
 <% end %>
-<%= link_to(following_user_path(@user), class:'user__tab') do %>
-  <p>フォロー</p>
-  <p class="user__count" id="following"><%= @user.following.length %></p>
-<% end %>
-<%= link_to(followers_user_path(@user), class:'user__tab') do %>
-  <p>フォロワー</p>
-  <p class="user__count" id="followers"><%= @user.followers.length %></p>
-<% end %>
+
+

--- a/app/views/users/_show_user.html.erb
+++ b/app/views/users/_show_user.html.erb
@@ -8,6 +8,16 @@
       <% end %>
     </div>
     <div class="user__name"><%= @user.name %></div>
+    <div class="user__follow_stats">
+      <%= link_to(following_user_path(@user), class:'user__follow') do %>
+        <p>フォロー</p>
+        <p class="user__count" id="following"><%= @user.following.length %></p>
+      <% end %>
+      <%= link_to(followers_user_path(@user), class:'user__follow') do %>
+        <p>フォロワー</p>
+        <div class="user__count" id="followers"><%= @user.followers.length %></div>
+      <% end %>
+    </div>
   </div>
   <div class="user__submenu">
     <%= render 'shared/user_submenu' if @user == current_user %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
   <% if @recipes.any? %>
     <%= render 'shared/recipe_list' %>
   <% else %>
-    <p class="list__notthing"><%= "#{@user.name}さんの投稿はありません。" %></p>
+    <p class="notthing"><%= "#{@user.name}さんの投稿はありません。" %></p>
   <% end %>
   <%= paginate @recipes %>
 </section>

--- a/app/views/users/show_consultation.html.erb
+++ b/app/views/users/show_consultation.html.erb
@@ -11,7 +11,7 @@
   <% if @consultations.any? %>
     <%= render 'shared/recipe_consultation' %>
   <% else %>
-    <p class="list__notthing"><%= "#{@user.name}さんの相談はありません。" %></p>
+    <p class="notthing"><%= "#{@user.name}さんの相談はありません。" %></p>
   <% end %>
   <%= paginate @consultations %>
 </section>

--- a/app/views/users/show_favorite.html.erb
+++ b/app/views/users/show_favorite.html.erb
@@ -1,0 +1,20 @@
+<section class="user">
+  <%= render 'show_user' %>
+</section>
+
+<%= render 'layouts/notifications' %>
+<section class="user-list">
+  <div class="subheader">
+    <div class="main-title"><%= @title %></div>
+  </div>
+
+  <% if @recipes.any? %>
+    <%= render 'shared/recipe_list' %>
+  <% else %>
+    <p class="notthing"><%= "#{@user.name}さんがいいねしたレシピはありません。" %></p>
+  <% end %>
+
+  
+  <%= paginate @recipes %>
+
+</section>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,11 +1,12 @@
-<section class="user">
-  <%= render 'show_user' %>
-</section>
-
 <section class="user-list">
-  <div class="subheader">
-    <div class="main-title"><%= @title %></div>
-  </div>
-  <%= render 'shared/user-list' %>
+  <div class="cooking-title"><%= @user.name %><%= @title %></div>
+
+  <% if @users.any? %>
+    <%= render 'shared/user-list' %>
+  <% else %>
+    <p class="notthing"><%= @message %></p>
+  <% end %>
   <%= paginate @users %>
+
+  <div class="btn-center"><%= link_to 'マイページに戻る', @user, class:"btn edit-cancel"%></div>
 </section>

--- a/app/views/users/show_inventory.html.erb
+++ b/app/views/users/show_inventory.html.erb
@@ -8,8 +8,11 @@
     <div class="main-title"><%= @title %></div>
   </div>
 
-  <%= render 'shared/food_inventory' %>
-  
+  <% if @inventories.any? %>
+    <%= render 'shared/food_inventory' %>
+  <% else %>
+    <p class="notthing"><%= "保存中の食材はありません。" %></p>
+  <% end %>
   <%= paginate @inventories %>
 
   <div class="btn-center"><%= link_to '保存中の食材を登録', new_inventory_path, class:"btn slide-bg" %></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
   resources :users do
     member do
-      get :following, :followers, :consultations, :inventories
+      get :following, :followers, :consultations, :inventories, :favorites
     end
   end
   


### PR DESCRIPTION
【変更点】
ユーザー詳細ページにユーザーに紐づく「いいね」したレシピのみを表示させるリンクを設置。

【その他の変更点】
フォロー・フォロワー一覧ページのスタイル変更。
フォロー・フォロワーが0人の場合はメッセージを表示する仕様に変更

ユーザー詳細ページのユーザー名の下にフォロー・フォロワーカウントとリンクを設置。

list__notthingクラスは様々な箇所で使うことになると判断し、base.scssに移動しnotthingクラスという名称に変更

【今後の改善したい点】
いいねした投稿の「いいね」を外すとそのまま残るためいいねを外したらリロードすることなく消える仕様に変更したい。