### PR TITLE
Feature/reply recipe comment

### DIFF
--- a/app/assets/stylesheets/templates/tag.scss
+++ b/app/assets/stylesheets/templates/tag.scss
@@ -1,7 +1,7 @@
 // 関連タグについてここから
 .tag {
   @extend .mb-sm;
-  
+  @extend .content-width;
   &__container {
     display: flex;
     flex-wrap: wrap;
@@ -9,6 +9,7 @@
   }
 
   &__none {
+    
     @extend .font-sm;
     color: $--c-dark-gray;
   }
@@ -19,6 +20,8 @@
     display: block;
     text-align: center;
     font-weight: 600;
+    border: 1px solid $--c-light-gray;
+    border-radius: 4px;
     letter-spacing: 1px;
     cursor: pointer;
     text-decoration: none !important;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,10 +5,14 @@ class CommentsController < ApplicationController
       flash[:notice] = 'コメントを投稿しました'
       redirect_to comment.recipe
     else
-      redirect_back fallback_location: comment.recipe, flash: {
-        comment: comment,
-        error_messages: comment.errors.full_messages
-      }
+      if comment.reply_comment.nil?
+        flash[:comment] = comment
+      else
+        flash[:comment_reply] = comment
+      end
+
+      flash[:error_messages] = comment.errors.full_messages
+      redirect_back fallback_location: comment.recipe
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,24 +5,21 @@ class CommentsController < ApplicationController
       flash[:notice] = 'コメントを投稿しました'
       redirect_to comment.recipe
     else
-      flash[:comment] = comment
-      flash[:error_messages] = comment.errors.full_messages
-      redirect_back fallback_location: comment.recipe
+      redirect_back fallback_location: comment.recipe, flash: {
+        comment: comment,
+        error_messages: comment.errors.full_messages
+      }
     end
   end
 
   def destroy
-    comment = Comment.find_by(recipe_id: params[:recipe_id])
-    if comment.user_id == current_user.id
-      comment.destroy
-    end
-    # redirect_to comment.boardで掲示板詳細画面に遷移
+    comment = Comment.find_by(id: params[:id], recipe_id: params[:recipe_id]).destroy
     redirect_to comment.recipe, flash: { notice: 'コメントが削除されました' }
   end
 
   private
 
   def comment_params
-    params.require(:comment).permit(:user_id, :recipe_id, :name, :comment)
+    params.require(:comment).permit(:user_id, :recipe_id, :reply_comment, :name, :content)
   end
 end

--- a/app/controllers/consultation_comments_controller.rb
+++ b/app/controllers/consultation_comments_controller.rb
@@ -5,10 +5,14 @@ class ConsultationCommentsController < ApplicationController
       flash[:notice] = '相談に対するコメントを投稿しました'
       redirect_to comment.consultation
     else
-      redirect_back fallback_location: comment.consultation, flash: {
-        comment: comment,
-        error_messages: comment.errors.full_messages
-      }
+      if comment.reply_comment.nil?
+        flash[:comment] = comment
+      else
+        flash[:comment_reply] = comment
+      end
+      
+      flash[:error_messages] = comment.errors.full_messages
+      redirect_back fallback_location: comment.consultation
     end
   end
 

--- a/app/controllers/consultation_comments_controller.rb
+++ b/app/controllers/consultation_comments_controller.rb
@@ -5,14 +5,15 @@ class ConsultationCommentsController < ApplicationController
       flash[:notice] = '相談に対するコメントを投稿しました'
       redirect_to comment.consultation
     else
-      flash[:consultation_comment] = comment
-      flash[:error_messages] = comment.errors.full_messages
-      redirect_back fallback_location: comment.consultation
+      redirect_back fallback_location: comment.consultation, flash: {
+        comment: comment,
+        error_messages: comment.errors.full_messages
+      }
     end
   end
 
   def destroy
-    comment = ConsultationComment.find(params[:id]).destroy
+    comment = ConsultationComment.find_by(id: params[:id], consultation_id: params[:consultation_id]).destroy
     redirect_to comment.consultation, flash: { notice: 'コメントが削除されました' }
   end
 

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -10,8 +10,8 @@ class ConsultationsController < ApplicationController
     @comments = ConsultationComment.includes([user: { avatar_attachment: :blob }]).where(consultation_id: @consultation.id)
 
     if user_signed_in?
-      @new_comment = current_user.consultation_comments.new
-      @comment_reply = current_user.consultation_comments.new
+      @new_comment = current_user.consultation_comments
+      @comment_reply = current_user.consultation_comments
     end
 
     # 閲覧数カウント

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -10,8 +10,8 @@ class ConsultationsController < ApplicationController
     @comments = ConsultationComment.includes([user: { avatar_attachment: :blob }]).where(consultation_id: @consultation.id)
 
     if user_signed_in?
-      @new_comment = current_user.consultation_comments
-      @comment_reply = current_user.consultation_comments
+      @new_comment = current_user.consultation_comments.new(flash[:comment])
+      @comment_reply = current_user.consultation_comments.new(flash[:comment_reply])
     end
 
     # 閲覧数カウント

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -13,7 +13,8 @@ class RecipesController < ApplicationController
     @comments = Comment.includes([:recipe], [user: { avatar_attachment: :blob }]).where(recipe_id: @recipe.id)
 
     if user_signed_in?
-      @comment = current_user.comments.new #=> formのパラメータ用にCommentオブジェクトを取得
+      @comment = current_user.comments.new(flash[:comment])
+      @comment_reply = current_user.comments.new(flash[:comment])
     end
   end
 

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -14,7 +14,7 @@ class RecipesController < ApplicationController
 
     if user_signed_in?
       @comment = current_user.comments.new(flash[:comment])
-      @comment_reply = current_user.comments.new(flash[:comment])
+      @comment_reply = current_user.comments.new(flash[:comment_reply])
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@
 # Table name: comments
 #
 #  id            :bigint           not null, primary key
-#  comment       :text(65535)      not null
+#  content       :text(65535)      not null
 #  reply_comment :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -19,7 +19,7 @@ class Comment < ApplicationRecord
   belongs_to :recipe
   belongs_to :user
 
-  has_many :replies, class_name: :ConsultationComment, foreign_key: :reply_comment, dependent: :destroy
+  has_many :replies, class_name: :Comment, foreign_key: :reply_comment, dependent: :destroy
 
-  validates :comment, presence: true, length: { maximum: 100 }
+  validates :content, presence: true, length: { maximum: 100 }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,12 +2,13 @@
 #
 # Table name: comments
 #
-#  id         :bigint           not null, primary key
-#  comment    :text(65535)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  recipe_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  comment       :text(65535)      not null
+#  reply_comment :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  recipe_id     :bigint           not null
+#  user_id       :bigint           not null
 #
 # Indexes
 #
@@ -17,6 +18,8 @@
 class Comment < ApplicationRecord
   belongs_to :recipe
   belongs_to :user
+
+  has_many :replies, class_name: :ConsultationComment, foreign_key: :reply_comment, dependent: :destroy
 
   validates :comment, presence: true, length: { maximum: 100 }
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,8 +1,11 @@
+<% @comments.each do |comment| %>
+
+<% if comment.reply_comment.present? || comment.blank? %>
+  <% next %>
+<% end %>
 <div class="comment__item">
-  <div class="comment__content"><%= comment.content %></div>
   <% if user_signed_in? && comment.user == current_user %>
-    <%= link_to image_tag("delete", alt: "delete"), recipe_comment_path(comment.recipe.id, comment.id),
-    class: 'comment__delete', method: :delete, data: { confirm: '削除してよろしいですか？' } %>
+    <%= link_to image_tag("delete", alt: "delete"), recipe_comment_path(comment.recipe.id, comment.id), class: 'comment__delete', method: :delete, data: { confirm: '削除してよろしいですか？' } %>
   <% end %>
   <div class="comment__info">
     <%= link_to user_path(id: comment.user_id), class: "comment__img" do %>
@@ -18,7 +21,14 @@
     <div class="post-date"><%= comment.created_at.to_s(:datetime_jp) %></div>
   </div>
 
+  <div class="comment__content"><%= comment.content %></div>
+  
+  <% if user_signed_in? %>
+    <%= render 'comments/reply_form', comment: comment %>
+  <% end %>
+
+  <%= render 'comments/reply_comment', comment: comment %>
 </div>
 
-
+<% end %>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,5 +1,5 @@
 <div class="comment__item">
-  <div class="comment__content"><%= comment.comment %></div>
+  <div class="comment__content"><%= comment.content %></div>
   <% if user_signed_in? && comment.user == current_user %>
     <%= link_to image_tag("delete", alt: "delete"), recipe_comment_path(comment.recipe.id, comment.id),
     class: 'comment__delete', method: :delete, data: { confirm: '削除してよろしいですか？' } %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model:[@recipe, @comment], method: :post, class: "comment__inputBx") do |f| %>
   <%= f.hidden_field :recipe_id, value: @recipe.id %>
   <%= f.hidden_field :user_id, value: current_user.id %>
-  <%= f.label :comment, "コメント投稿はこちら", class: 'comment__label'%>
-  <%= f.text_area :comment, placeholder: "100文字まで入力可能です", class: 'comment__area' %>
+  <%= f.label :content, "コメント投稿はこちら", class: 'comment__label'%>
+  <%= f.text_area :content, placeholder: "100文字まで入力可能です", class: 'comment__area' %>
   <div class="submit-btn"><%= f.button "送信する" , class:"btn slide-bg"%></div>
 <% end %>

--- a/app/views/comments/_reply_comment.html.erb
+++ b/app/views/comments/_reply_comment.html.erb
@@ -1,0 +1,22 @@
+<% comment.replies.order(:created_at).each do |reply| %>
+  <div class="comment__reply-item">
+    <div class="comment__info">
+
+      <%= link_to user_path(id: reply.user_id), class: "comment__img" do %>
+        <% if reply.user.avatar.attached? %>
+          <%= image_tag(reply.user.avatar) %>
+        <% else %>
+          <%= image_tag 'default_user' %>
+        <% end %>
+      <% end %>
+
+      <%= link_to reply.user.name, user_path(id: reply.user_id), class: "comment__name"%>
+    </div>
+    <div class="comment__reply-content">
+      <%= reply.content %>
+      <% if user_signed_in? && reply.user == current_user %>
+        <%= link_to image_tag("delete"), recipe_comment_path(reply.recipe.id, reply.id), class: 'comment__delete', method: :delete, data: { confirm: '削除してもよろしいですか？' } %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/_reply_form.html.erb
+++ b/app/views/comments/_reply_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with(model: [@recipe, @comment_reply], class: "comment__replyBx") do |f| %>
+  <%= f.text_field :content , placeholder: "このコメントに返信" %>
+  <%= f.hidden_field :reply_comment, value: comment.id %>
+  <%= f.hidden_field :recipe_id, value: @recipe.id %>
+  <%= f.hidden_field :user_id, value: current_user.id %>
+
+  <div class="comment__reply-submit"><%= f.button image_tag('send-comment') %></div>
+<% end %>

--- a/app/views/consultation_comments/_form.html.erb
+++ b/app/views/consultation_comments/_form.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/error_messages' %>
-
 <%= form_with(model:[@consultation, @new_comment], class: "comment__inputBx") do |f| %>
   <%= f.hidden_field :consultation_id, value: @consultation.id %>
   <%= f.hidden_field :user_id, value: current_user.id %>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -1,9 +1,12 @@
 <div class="cooking-title">相談詳細</div>
+
 <section class="consultation">
-    <!-- 投稿完了後のフラッシュメッセージ -->
-    <% unless flash[:error_messages] %>
-      <%= render 'layouts/notifications' %>
-    <% end %>
+  <!-- 投稿完了後のフラッシュメッセージ -->
+  <% unless flash[:error_messages] %>
+    <%= render 'layouts/notifications' %>
+  <% else %>
+    <%= render 'shared/error_messages' %>
+  <% end %>
   <div class="consultation__inner">
     <div class="consultation__info">
         <%= link_to(user_path(id: @consultation.user_id), class:'consultation__user-show-img') do %>

--- a/app/views/shared/_consultation_comment.html.erb
+++ b/app/views/shared/_consultation_comment.html.erb
@@ -2,8 +2,7 @@
   <div class="comment__inner">
     <div class="comment__texts">
       <div class="comment__count">コメント<%= comments.where(reply_comment: nil).length %>件</div>
-      <%# consultation_comments/_consultation_comment.html.erbにレンダリング %>
-      <%= render partial: 'consultation_comments/comment', locals:{ comments: comments } %>
+      <%= render 'consultation_comments/comment', comments: comments %>
     </div>
     <% if user_signed_in? %>
       <div class="comment__form">

--- a/app/views/shared/_recipe_comment.html.erb
+++ b/app/views/shared/_recipe_comment.html.erb
@@ -1,12 +1,12 @@
 <section class="comment">
   <div class="comment__inner">
     <div class="comment__texts">
-      <div class="comment__count">コメント<%= comments.length %>件</div>
-      <%= render comments %>
+      <div class="comment__count">コメント<%= comments.where(reply_comment: nil).length %>件</div>
+      <%= render "comments/comment" %>
     </div>
     <% if user_signed_in? %>
       <div class="comment__form">
-        <%= render partial: 'comments/form', locals:{ recipe: @recipe } %>
+        <%= render 'comments/form' %>
       </div>
     <% end %>
   </div>

--- a/db/migrate/20210423143908_add_column_to_comments.rb
+++ b/db/migrate/20210423143908_add_column_to_comments.rb
@@ -1,0 +1,5 @@
+class AddColumnToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :reply_comment, :integer
+  end
+end

--- a/db/migrate/20210423144651_rename_comment_column_to_comments.rb
+++ b/db/migrate/20210423144651_rename_comment_column_to_comments.rb
@@ -1,0 +1,5 @@
+class RenameCommentColumnToComments < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :comments, :comment, :content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_23_143908) do
+ActiveRecord::Schema.define(version: 2021_04_23_144651) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2021_04_23_143908) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "recipe_id", null: false
-    t.text "comment", null: false
+    t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_150146) do
+ActiveRecord::Schema.define(version: 2021_04_23_143908) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2021_03_11_150146) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
+    t.integer "reply_comment"
     t.index ["recipe_id"], name: "index_comments_on_recipe_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,12 +2,13 @@
 #
 # Table name: comments
 #
-#  id         :bigint           not null, primary key
-#  comment    :text(65535)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  recipe_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  comment       :text(65535)      not null
+#  reply_comment :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  recipe_id     :bigint           not null
+#  user_id       :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -3,7 +3,7 @@
 # Table name: comments
 #
 #  id            :bigint           not null, primary key
-#  comment       :text(65535)      not null
+#  content       :text(65535)      not null
 #  reply_comment :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -2,12 +2,13 @@
 #
 # Table name: comments
 #
-#  id         :bigint           not null, primary key
-#  comment    :text(65535)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  recipe_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  comment       :text(65535)      not null
+#  reply_comment :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  recipe_id     :bigint           not null
+#  user_id       :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -3,7 +3,7 @@
 # Table name: comments
 #
 #  id            :bigint           not null, primary key
-#  comment       :text(65535)      not null
+#  content       :text(65535)      not null
 #  reply_comment :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null


### PR DESCRIPTION
【変更点】
commentテーブルにreply_commentカラムを追加
コメントフォームとコメント返信フォームでフラッシュメッセージの切り分けに成功

今回の参考URL⇨https://qiita.com/Jwataru/items/a8e0120dd32761d70bfa

【その他の変更点】
commentテーブルのcommentカラムをcontentカラムに変更
tag__noneクラスにcontent_widthクラスを適用
相談に対するコメント機能のフラッシュメッセージ(エラー)の位置を変更


【今後の修正点】
コメントにもページネーションを追加した方が良い可能性あり
コメント返信フォームが複数あるため特定のコメント返信フォームにフラッシュメッセージ適用ができないため、全てのコメント返信フォームにフラッシュメッセージが入ってしまう点は今後改善