### PR TITLE
相談一覧ページのソート機能のシステムスペック完了

### DIFF
--- a/spec/factories/consultations.rb
+++ b/spec/factories/consultations.rb
@@ -18,5 +18,11 @@ FactoryBot.define do
   factory :consultation do
     title { "相談タイトル" }
     content { "相談内容" }
+
+    factory :other_consultation do
+      title { "相談タイトル2" }
+      content { "相談内容2" }
+      created_at { 1.day.ago }
+    end
   end
 end


### PR DESCRIPTION
【システムスペック】
・デフォルトは投稿が新しい順で表示される
・投稿の古い順に並び替えできる
・★気になる順に並び替えできる
・回答数が多い順に並び替えできる