### PR TITLE
ゲストユーザーの場合は、退会処理を実施させない仕様に変更しました。

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,7 +30,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     # ゲストユーザーの更新・削除不可
     def forbid_test_user
       if resource.email == "guest@example.com"
-        flash[:alert] = "ゲストユーザーの更新・削除はできません。"
+        flash[:alert] = "ゲストユーザーの編集・退会はできません。"
         redirect_to root_path
       end
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,7 +5,6 @@ class Users::SessionsController < Devise::SessionsController
 
   def guest_sign_in
     user = User.guest
-    user.skip_confirmation!
     sign_in user
     redirect_to root_path, flash: { notice: 'ゲストユーザーとしてログインしました。' }
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:destroy, :inventories]
-  before_action :set_user, only: [:show , :destroy, :following, :followers, :consultations, :favorites, :interests, :inventories, :withdrawal, :reregistration]
+  before_action :set_user, only: [:show , :destroy, :following, :followers, :consultations, :favorites, :interests, :inventories, :unsubscribe, :withdrawal, :reregistration]
+
+  before_action :withdrawal_forbid_guest_user, only: [:unsubscribe, :withdrawal]
 
   def index
     @users = User.includes([:recipes], [avatar_attachment: :blob]).page(params[:page]).per(6).order(id: :ASC)
@@ -58,9 +60,12 @@ class UsersController < ApplicationController
       redirect_to root_path
     end
   end
+  
+  def unsubscribe
+    
+  end
 
   def withdrawal
-    # is_deletedカラムをtrueに変更することにより削除フラグを立てる
     @user.update(is_deleted: true)
     reset_session
     flash[:notice] = "退会処理が完了しました。"
@@ -80,7 +85,6 @@ class UsersController < ApplicationController
       flash[:alert] = "このアカウントは退会しておりません。"
       redirect_to new_user_session_path
     end
-
   end
 
   def reregistration
@@ -93,5 +97,13 @@ class UsersController < ApplicationController
 
     def set_user
       @user = User.find(params[:id])
+    end
+
+    # ゲストユーザーの更新・削除不可
+    def withdrawal_forbid_guest_user
+      if @user.email == "guest@example.com"
+        flash[:alert] = "ゲストユーザーの退会処理はできません。"
+        redirect_to root_path
+      end
     end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -80,7 +80,7 @@
         </div>
 
         <div class="login__inputBx">
-          <%= link_to "退会", unsubscribe_path(@user) %>
+          <%= link_to "退会", unsubscribe_user_path(@user) %>
         </div>
       <% end %>
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   resources :relationships, only: [:create, :destroy]
 
   # 退会確認画面
-  get '/users/:id/unsubscribe' => 'users#unsubscribe', as: 'unsubscribe'
+  # get '/users/:id/unsubscribe' => 'users#unsubscribe', as: 'unsubscribe'
   # 論理削除用のルーティング
   patch '/users/:id/withdrawal' => 'users#withdrawal', as: 'withdrawal'
   
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
 
   resources :users do
     member do
-      get :following, :followers, :consultations, :favorites, :interests, :inventories
+      get :following, :followers, :consultations, :favorites, :interests, :inventories, :unsubscribe
     end
   end
 


### PR DESCRIPTION
一時的に現在のパスワードで入力せずとも編集できる仕様(下記リンク参照)にしたところ、ゲストユーザーのプロフィール画像を設定できました。

https://note.com/ya_jp/n/n5b565cd7ec93

ゲストユーザーはユーザー編集できない仕様・編集時に現在のパスワードが必要になる仕様に戻しました。

【その他の変更点】
ゲストユーザーログイン時に直接パスを打つと退会処理ができたので、withdrawal_forbid_guest_userを追加し、退会処理を実施させない仕様にしました